### PR TITLE
Refactor the initial IT to use less repeating code

### DIFF
--- a/nexus-repository-cabal-it/src/test/java/org/sonatype/nexus/plugins/cabal/internal/CabalProxyIT.java
+++ b/nexus-repository-cabal-it/src/test/java/org/sonatype/nexus/plugins/cabal/internal/CabalProxyIT.java
@@ -31,16 +31,12 @@ import org.ops4j.pax.exam.Option;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.sonatype.goodies.httpfixture.server.fluent.Behaviours.content;
 import static org.sonatype.goodies.httpfixture.server.fluent.Behaviours.error;
-import static org.sonatype.nexus.plugins.cabal.internal.util.CabalPathUtils.PACKAGE_FILENAME;
 import static org.sonatype.nexus.testsuite.testsupport.FormatClientSupport.status;
 
 public class CabalProxyIT
     extends CabalITSupport
 {
-  // @todo Change test path for your format
-  private static final String TEST_PATH = "some/valid/path/for/your/remote/" + PACKAGE_FILENAME;
 
   private static final String VERSION = "0.1.0.0";
 

--- a/nexus-repository-cabal-it/src/test/java/org/sonatype/nexus/plugins/cabal/internal/CabalProxyIT.java
+++ b/nexus-repository-cabal-it/src/test/java/org/sonatype/nexus/plugins/cabal/internal/CabalProxyIT.java
@@ -37,7 +37,6 @@ import static org.sonatype.nexus.testsuite.testsupport.FormatClientSupport.statu
 public class CabalProxyIT
     extends CabalITSupport
 {
-
   private static final String VERSION = "0.1.0.0";
 
   private static final String NAME_PACKAGE = "AlgoRhythm";
@@ -79,6 +78,14 @@ public class CabalProxyIT
   private static final String PATH_TAR_GZ_PACKAGE = DIRECTORY_PACKAGE + FILE_TAR_GZ_PACKAGE;
 
   private static final String PATH_CABAL_PACKAGE = DIRECTORY_PACKAGE + FILE_CABAL_PACKAGE;
+
+  private static final String PATH_INVALID = DIRECTORY_INVALID + FILE_TAR_GZ_PACKAGE;
+
+  public static final String MIME_GZIP = "application/x-gzip";
+
+  public static final String MIME_TEXT = "text/plain";
+
+  public static final String MIME_JSON = "application/json";
 
   private CabalClient proxyClient;
 
@@ -133,11 +140,14 @@ public class CabalProxyIT
     }
   }
 
+  @Test
+  public void invalidPathsReturn404() throws Exception {
+    assertThat(status(proxyClient.get(PATH_INVALID)), is(HttpStatus.NOT_FOUND));
+  }
 
   @Test
   public void retrievePackageWhenRemoteOnline() throws Exception {
-    proxyClient.get(PATH_TAR_GZ_PACKAGE);
-    assertThat(status(proxyClient.get(PATH_TAR_GZ_PACKAGE)), is(200));
+    assertThat(status(proxyClient.get(PATH_TAR_GZ_PACKAGE)), is(HttpStatus.OK));
 
     final Component component = findComponent(proxyRepo, NAME_PACKAGE);
     assertThat(component.version(), is(VERSION));
@@ -146,47 +156,48 @@ public class CabalProxyIT
     final Asset asset = findAsset(proxyRepo, PATH_TAR_GZ_PACKAGE);
     assertThat(asset.format(), is("cabal"));
     assertThat(asset.name(), is(PATH_TAR_GZ_PACKAGE));
-    assertThat(asset.contentType(), is("application/x-gzip"));
+    assertThat(asset.contentType(), is(MIME_GZIP));
   }
 
   @Test
   public void retrieveCabalFileWhenRemoteOnline() throws Exception {
-    proxyClient.get(PATH_CABAL_PACKAGE);
-
+    assertThat(status(proxyClient.get(PATH_CABAL_PACKAGE)), is(HttpStatus.OK));
     final Asset asset = findAsset(proxyRepo, PATH_CABAL_PACKAGE);
-    assertThat(status(proxyClient.get(PATH_CABAL_PACKAGE)), is(200));
+    assertThat(asset.format(), is("cabal"));
+    assertThat(asset.name(), is(PATH_CABAL_PACKAGE));
+    assertThat(asset.contentType(), is(MIME_TEXT));
   }
 
   @Test
   public void retrieveIncrementalIndexWhenRemoteOnline() throws Exception {
-    proxyClient.get(FILE_INCREMENTAL_INDEX);
-
+    assertThat(status(proxyClient.get(FILE_INCREMENTAL_INDEX)), is(HttpStatus.OK));
     final Asset asset = findAsset(proxyRepo, FILE_INCREMENTAL_INDEX);
-    assertThat(status(proxyClient.get(FILE_INCREMENTAL_INDEX)), is(200));
+    assertThat(asset.name(), is(FILE_INCREMENTAL_INDEX));
+    assertThat(asset.contentType(), is(MIME_GZIP));
   }
 
   @Test
   public void retrievetimeStampWhenRemoteOnline() throws Exception {
-    proxyClient.get(FILE_TIMESTAMP);
-
+    assertThat(status(proxyClient.get(FILE_TIMESTAMP)), is(HttpStatus.OK));
     final Asset asset = findAsset(proxyRepo, FILE_TIMESTAMP);
-    assertThat(status(proxyClient.get(FILE_TIMESTAMP)), is(200));
+    assertThat(asset.name(), is(FILE_TIMESTAMP));
+    assertThat(asset.contentType(), is(MIME_JSON));
   }
 
   @Test
   public void retrieveMirrorsJSONWhenRemoteOnline() throws Exception {
-    proxyClient.get(FILE_MIRRORS);
-
+    assertThat(status(proxyClient.get(FILE_MIRRORS)), is(HttpStatus.OK));
     final Asset asset = findAsset(proxyRepo, FILE_MIRRORS);
-    assertThat(status(proxyClient.get(FILE_MIRRORS)), is(200));
+    assertThat(asset.name(), is(FILE_MIRRORS));
+    assertThat(asset.contentType(), is(MIME_JSON));
   }
 
   @Test
   public void retrieveRootJSONWhenRemoteOnline() throws Exception {
-    proxyClient.get(FILE_ROOT);
-
+    assertThat(status(proxyClient.get(FILE_ROOT)), is(HttpStatus.OK));
     final Asset asset = findAsset(proxyRepo, FILE_ROOT);
-    assertThat(status(proxyClient.get(FILE_ROOT)), is(200));
+    assertThat(asset.name(), is(FILE_ROOT));
+    assertThat(asset.contentType(), is(MIME_JSON));
   }
 
   @Test
@@ -198,7 +209,7 @@ public class CabalProxyIT
     finally {
       server.stop();
     }
-    assertThat(status(proxyClient.get(PATH_TAR_GZ_PACKAGE)), is(200));
+    assertThat(status(proxyClient.get(PATH_TAR_GZ_PACKAGE)), is(HttpStatus.OK));
   }
 
   @After

--- a/nexus-repository-cabal-it/src/test/java/org/sonatype/nexus/plugins/cabal/internal/CabalProxyIT.java
+++ b/nexus-repository-cabal-it/src/test/java/org/sonatype/nexus/plugins/cabal/internal/CabalProxyIT.java
@@ -193,21 +193,17 @@ public class CabalProxyIT
     assertThat(status(proxyClient.get(FILE_ROOT)), is(200));
   }
 
-  //@Test
-  //public void retrieveCabalWhenRemoteOffline() throws Exception {
-  //  Server server = Server.withPort(0).serve("/*")
-  //      .withBehaviours(content("Response"))
-  //      .start();
-  //  try {
-  //    proxyRepo = repos.createCabalProxy("cabal-test-proxy-offline", server.getUrl().toExternalForm());
-  //    proxyClient = cabalClient(proxyRepo);
-  //    proxyClient.get(TEST_PATH);
-  //  }
-  //  finally {
-  //    server.stop();
-  //  }
-  //  assertThat(status(proxyClient.get(TEST_PATH)), is(200));
-  //}
+  @Test
+  public void retrieveCabalWhenRemoteOffline() throws Exception {
+    try {
+      proxyRepo = repos.createCabalProxy("cabal-test-proxy-offline", server.getUrl().toExternalForm());
+      proxyClient.get(PATH_TAR_GZ_PACKAGE);
+    }
+    finally {
+      server.stop();
+    }
+    assertThat(status(proxyClient.get(PATH_TAR_GZ_PACKAGE)), is(200));
+  }
 
   @After
   public void tearDown() throws Exception {

--- a/nexus-repository-cabal/src/main/java/org/sonatype/nexus/plugins/cabal/internal/CabalRecipeSupport.groovy
+++ b/nexus-repository-cabal/src/main/java/org/sonatype/nexus/plugins/cabal/internal/CabalRecipeSupport.groovy
@@ -16,7 +16,6 @@ import javax.inject.Inject
 import javax.inject.Provider
 
 import org.sonatype.nexus.plugins.cabal.internal.security.CabalSecurityFacet
-
 import org.sonatype.nexus.repository.Format
 import org.sonatype.nexus.repository.RecipeSupport
 import org.sonatype.nexus.repository.Type
@@ -44,8 +43,6 @@ import org.sonatype.nexus.repository.view.matchers.LiteralMatcher
 import org.sonatype.nexus.repository.view.matchers.logic.LogicMatchers
 import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher
 
-import static org.sonatype.nexus.plugins.cabal.internal.util.CabalPathUtils.ASSET_FILENAME
-import static org.sonatype.nexus.plugins.cabal.internal.util.CabalPathUtils.PACKAGE_FILENAME
 import static org.sonatype.nexus.repository.http.HttpMethods.GET
 import static org.sonatype.nexus.repository.http.HttpMethods.HEAD
 
@@ -113,8 +110,6 @@ abstract class CabalRecipeSupport
     super(type, format)
   }
 
-  // @todo Add/change matcher methods here
-
   static Matcher packageCabalMatcher() {
     buildTokenMatcherForPatternAndAssetKind("/package/{fileName:.+}.tar.gz", AssetKind.ARCHIVE, GET, HEAD)
   }
@@ -141,10 +136,6 @@ abstract class CabalRecipeSupport
 
   static Matcher rootMatcher() {
     buildLiteralMatcherForPatternAndAssetKind("/root.json", AssetKind.ROOT, GET, HEAD)
-  }
-
-  static Matcher assetCabalMatcher() {
-    buildTokenMatcherForPatternAndAssetKind("/{myTokenName:.+}/${ASSET_FILENAME}", AssetKind.ARCHIVE, GET, HEAD)
   }
 
   static Matcher buildTokenMatcherForPatternAndAssetKind(final String pattern,

--- a/nexus-repository-cabal/src/main/java/org/sonatype/nexus/plugins/cabal/internal/proxy/CabalProxyFacetImpl.java
+++ b/nexus-repository-cabal/src/main/java/org/sonatype/nexus/plugins/cabal/internal/proxy/CabalProxyFacetImpl.java
@@ -44,7 +44,6 @@ import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher;
 import org.sonatype.nexus.transaction.UnitOfWork;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.sonatype.nexus.plugins.cabal.internal.util.CabalPathUtils.PACKAGE_FILENAME;
 import static org.sonatype.nexus.repository.storage.AssetEntityAdapter.P_ASSET_KIND;
 
 /**
@@ -89,9 +88,6 @@ public class CabalProxyFacetImpl
     AssetKind assetKind = context.getAttributes().require(AssetKind.class);
     TokenMatcher.State matcherState;
     switch (assetKind) {
-      case PACKAGES:
-        matcherState = cabalPathUtils.matcherState(context);
-        return getAsset(cabalPathUtils.buildAssetPath(matcherState, PACKAGE_FILENAME));
       case ARCHIVE:
         matcherState = cabalPathUtils.matcherState(context);
         return getAsset(cabalPathUtils.buildAssetPath(matcherState));
@@ -130,11 +126,6 @@ public class CabalProxyFacetImpl
     AssetKind assetKind = context.getAttributes().require(AssetKind.class);
     TokenMatcher.State matcherState;
     switch (assetKind) {
-      case PACKAGES:
-        matcherState = cabalPathUtils.matcherState(context);
-        return putMetadata(content,
-            assetKind,
-            cabalPathUtils.buildAssetPath(matcherState, PACKAGE_FILENAME));
       case ARCHIVE:
         matcherState = cabalPathUtils.matcherState(context);
         return putCabalPackage(content,

--- a/nexus-repository-cabal/src/main/java/org/sonatype/nexus/plugins/cabal/internal/proxy/CabalProxyRecipe.groovy
+++ b/nexus-repository-cabal/src/main/java/org/sonatype/nexus/plugins/cabal/internal/proxy/CabalProxyRecipe.groovy
@@ -89,7 +89,7 @@ class CabalProxyRecipe
     addBrowseUnsupportedRoute(builder)
 
     // @todo Add matcher methods to this list
-    [packageCabalMatcher(), assetCabalMatcher(), cabalMatcher(), incrementalPackageMatcher(), timestampMatcher(), snapshotMatcher(), mirrorsMatcher(), rootMatcher()].each { matcher ->
+    [packageCabalMatcher(), cabalMatcher(), incrementalPackageMatcher(), timestampMatcher(), snapshotMatcher(), mirrorsMatcher(), rootMatcher()].each { matcher ->
       builder.route(new Route.Builder().matcher(matcher)
           .handler(timingHandler)
           .handler(securityHandler)

--- a/nexus-repository-cabal/src/main/java/org/sonatype/nexus/plugins/cabal/internal/util/CabalPathUtils.java
+++ b/nexus-repository-cabal/src/main/java/org/sonatype/nexus/plugins/cabal/internal/util/CabalPathUtils.java
@@ -27,39 +27,21 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Named
 @Singleton
 public class CabalPathUtils
-{
-  // @todo Change this to a valid filename for your format
-  public static final String PACKAGE_FILENAME = "myPackageFilename.txt";
-
-  // @todo Change this to a valid filename for your format
-  public static final String ASSET_FILENAME = "myAssetFilename.fil";
-
-  public TokenMatcher.State matcherState(final Context context) {
+{ public TokenMatcher.State matcherState(final Context context) {
     return context.getAttributes().require(TokenMatcher.State.class);
   }
 
-  // @todo Change this to a valid token for your format
-  public String version(final TokenMatcher.State state) {
-    return match(state, "version");
-  }
+  public String version(final TokenMatcher.State state) { return match(state, "version"); }
 
-  public String packageName(final TokenMatcher.State state) {
-    return match(state, "packageName");
-  }
+  public String packageName(final TokenMatcher.State state) { return match(state, "packageName"); }
 
-  public String fileName(final TokenMatcher.State state) {
-    return match(state, "fileName");
-  }
+  public String fileName(final TokenMatcher.State state) { return match(state, "fileName"); }
 
   private String match(final TokenMatcher.State state, final String name) {
     checkNotNull(state);
     String result = state.getTokens().get(name);
     checkNotNull(result);
     return result;
-  }
-
-  public String buildAssetPath(final State matcherState, final String assetName) {
-    return String.format("/%s/%s", version(matcherState), assetName);
   }
 
   public String buildAssetPath(final State matcherState) {


### PR DESCRIPTION
Refactor the initial IT to use less repeating code

This pull request makes the following changes:
* Pulled out server starting/stopping code in each individual test to `@Before` and `@After` blocks
* Refactored initial tests from format generator
* Cleaned out unused constants/methods from format generator